### PR TITLE
Remove space from LOG_TAG

### DIFF
--- a/lights.cpp
+++ b/lights.cpp
@@ -15,7 +15,7 @@
  * ...................
  * ********************************************************************/
 
-#define LOG_TAG "Lights Hal"
+#define LOG_TAG "LightsHal"
 
 #include <cutils/log.h>
 #include <cutils/atomic.h>


### PR DESCRIPTION
Having spaces in logcat tags prevents the logcat tool from filtering them. The consensus on [this StackOverflow question](https://stackoverflow.com/q/4971622) is that you have to use grep in order to find the tag, instead of being able to use the logcat filter-spec syntax. However, this is not possible to do on-device.